### PR TITLE
Error render atom page

### DIFF
--- a/src/views/atom.blade.php
+++ b/src/views/atom.blade.php
@@ -1,7 +1,7 @@
 {!! '<'.'?'.'xml version="1.0" encoding="UTF-8" ?>'."\n" !!}
 <feed xmlns="http://www.w3.org/2005/Atom"<?php foreach($namespaces as $n) echo " "+$n; ?>>
-    <title type="html">{{ $channel['title'] }}</title>
-    <subtitle type="html">{{ $channel['description'] }}</subtitle>
+    <title type="html">{!! $channel['title'] !!}</title>
+    <subtitle type="html">{!! $channel['description'] !!}</subtitle>
     <link href="{{ $channel['link'] }}"></link>
     <id>{{ $channel['link'] }}</id>
     <link rel="alternate" type="text/html" href="{{ $channel['link'] }}" ></link>


### PR DESCRIPTION
When title or description atom page contains tildes, the page no render (check in firefox)