### PR TITLE
Don't use html entities in item title

### DIFF
--- a/src/views/rss.blade.php
+++ b/src/views/rss.blade.php
@@ -16,7 +16,7 @@
         <lastBuildDate>{{ $channel['pubdate'] }}</lastBuildDate>
         @foreach($items as $item)
         <item>
-            <title>{{ $item['title'] }}</title>
+            <title>{!! $item['title'] !!}</title>
             <link>{{ $item['link'] }}</link>
             <guid isPermaLink="true">{{ $item['link'] }}</guid>
             <description>{!! $item['description'] !!}</description>


### PR DESCRIPTION
A french character with an accent, like `é`, in the items' title will be converted to a html entity, which makes the feed fail at W3C feed validator.