### PR TITLE
Make the attribute of ref in the tag of link be customized

### DIFF
--- a/src/Roumen/Feed/Feed.php
+++ b/src/Roumen/Feed/Feed.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Facades\Cache;
 
 class Feed
 {
+    const DEFAULT_REF = 'self';
+
     /**
      * @var array
      */
@@ -35,6 +37,11 @@ class Feed
      * @var string
      */
     public $link;
+
+    /**
+     * @var string
+     */
+    public $ref;
 
     /**
      * @var string
@@ -219,6 +226,7 @@ class Feed
 
         if (empty($this->lang)) $this->lang = Config::get('application.language');
         if (empty($this->link)) $this->link = Config::get('application.url');
+        if (empty($this->ref)) $this->ref = self::DEFAULT_REF;
         if (empty($this->pubdate)) $this->pubdate = date('D, d M Y H:i:s O');
 
         foreach($this->items as $k => $v)
@@ -237,6 +245,7 @@ class Feed
             'ga'            =>  $this->ga,
             'related'       =>  $this->related,
             'link'          =>  $this->link,
+            'ref'           =>  $this->ref,
             'pubdate'       =>  $this->formatDate($this->pubdate, $format),
             'lang'          =>  $this->lang,
             'copyright'     =>  $this->copyright

--- a/src/views/atom.blade.php
+++ b/src/views/atom.blade.php
@@ -5,7 +5,7 @@
     <link href="{{ Request::url() }}"></link>
     <id>{{ $channel['link'] }}</id>
     <link rel="alternate" type="text/html" href="{{ Request::url() }}" ></link>
-    <link rel="self" type="application/atom+xml" href="{{ $channel['link'] }}" ></link>
+    <link rel="{{ $channel['ref'] }}" type="application/atom+xml" href="{{ $channel['link'] }}" ></link>
 @if (!empty($channel['logo']))
     <logo>{{ $channel['logo'] }}</logo>
 @endif

--- a/src/views/rss.blade.php
+++ b/src/views/rss.blade.php
@@ -4,7 +4,7 @@
         <title>{!! $channel['title'] !!}</title>
         <link>{{ Request::url() }}</link>
         <description><![CDATA[{!! $channel['description'] !!}]]></description>
-        <atom:link href="{{ $channel['link'] }}" rel="self"></atom:link>
+        <atom:link href="{{ $channel['link'] }}" rel="{{ $channel['ref'] }}"></atom:link>
         @if (!empty($channel['copyright']))
         <copyright>{{ $channel['copyright'] }}</copyright>
         @endif

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -16,6 +16,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
         $this->feed->title = 'TestTitle';
         $this->feed->description = 'TestDescription';
         $this->feed->link = 'http://roumen.it/';
+        $this->feed->ref = 'hub';
         $this->feed->logo = "http://roumen.it/favicon.png";
         $this->feed->icon = "http://roumen.it/favicon.png";
         $this->feed->pubdate = '2014-02-29 00:00:00';
@@ -29,6 +30,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
         $this->assertEquals('TestTitle', $this->feed->title);
         $this->assertEquals('TestDescription', $this->feed->description);
         $this->assertEquals('http://roumen.it/', $this->feed->link);
+        $this->assertEquals('hub', $this->feed->ref);
         $this->assertEquals("http://roumen.it/favicon.png", $this->feed->logo);
         $this->assertEquals("http://roumen.it/favicon.png", $this->feed->icon);
         $this->assertEquals('2014-02-29 00:00:00', $this->feed->pubdate);


### PR DESCRIPTION
Hi Roumen,

We need to customize the `ref` attribute in `//atom:link` tag to notify the [google hub](https://pubsubhubbub.appspot.com/).

