### PR TITLE
Make the domain of rss service be hidden

### DIFF
--- a/src/Roumen/Feed/Feed.php
+++ b/src/Roumen/Feed/Feed.php
@@ -10,6 +10,7 @@
  */
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Cache;
@@ -32,6 +33,11 @@ class Feed
      * @var string
      */
     public $description = 'My feed description';
+
+    /**
+     * @var string
+     */
+    public $domain;
 
     /**
      * @var string
@@ -244,6 +250,7 @@ class Feed
             'cover'         =>  $this->cover,
             'ga'            =>  $this->ga,
             'related'       =>  $this->related,
+            'rssLink'       =>  $this->getRssLink(),
             'link'          =>  $this->link,
             'ref'           =>  $this->ref,
             'pubdate'       =>  $this->formatDate($this->pubdate, $format),
@@ -495,4 +502,19 @@ class Feed
         $this->items[] = $item;
     }
 
+    /**
+     * Generate rss link
+     *
+     * @author Cara Wang <caraw@cnyes.com>
+     * @since  2016/09/09
+     */
+    private function getRssLink()
+    {
+        $rssLink = Request::url();
+        if (!empty($this->domain)) {
+            $rssLink = sprintf('%s/%s', rtrim($this->domain, '/'), ltrim(Request::path(), '/'));
+        }
+
+        return $rssLink;
+    }
 }

--- a/src/views/atom.blade.php
+++ b/src/views/atom.blade.php
@@ -2,9 +2,9 @@
 <feed xmlns="http://www.w3.org/2005/Atom"<?php foreach($namespaces as $n) echo " ".$n; ?>>
     <title type="text">{!! $channel['title'] !!}</title>
     <subtitle type="html"><![CDATA[{!! $channel['description'] !!}]]></subtitle>
-    <link href="{{ Request::url() }}"></link>
+    <link href="{{ $channel['rssLink'] }}"></link>
     <id>{{ $channel['link'] }}</id>
-    <link rel="alternate" type="text/html" href="{{ Request::url() }}" ></link>
+    <link rel="alternate" type="text/html" href="{{ $channel['rssLink'] }}" ></link>
     <link rel="{{ $channel['ref'] }}" type="application/atom+xml" href="{{ $channel['link'] }}" ></link>
 @if (!empty($channel['logo']))
     <logo>{{ $channel['logo'] }}</logo>

--- a/src/views/rss.blade.php
+++ b/src/views/rss.blade.php
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:webfeeds="http://webfeeds.org/rss/1.0" xmlns:media="http://search.yahoo.com/mrss/"<?php foreach($namespaces as $n) echo " ".$n; ?>>
     <channel>
         <title>{!! $channel['title'] !!}</title>
-        <link>{{ Request::url() }}</link>
+        <link>{{ $channel['rssLink'] }}</link>
         <description><![CDATA[{!! $channel['description'] !!}]]></description>
         <atom:link href="{{ $channel['link'] }}" rel="{{ $channel['ref'] }}"></atom:link>
         @if (!empty($channel['copyright']))

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -156,7 +156,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
     public function testGetRssLinkByDefault()
     {
         $requestUrl = 'http://real.domain.need.to.be.hidden/test.xml';
-        $this->get($requestUrl);
+        $this->call('get', $requestUrl);
 
         $reflectionMethod = new ReflectionMethod(Roumen\Feed\Feed::class, 'getRssLink');
         $reflectionMethod->setAccessible(true);
@@ -168,7 +168,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
     public function testGetRssLinkWithDomainSetting()
     {
         $requestUrl = 'http://real.domain.need.to.be.hidden/test.xml';
-        $this->get($requestUrl);
+        $this->call('get', $requestUrl);
 
         $this->feed->domain = 'http://rss.service.com/';
 

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -176,6 +176,6 @@ class FeedTest extends Orchestra\Testbench\TestCase
         $reflectionMethod->setAccessible(true);
         $result = $reflectionMethod->invokeArgs($this->feed, []);
 
-        $this->assertEquals('http://rss.roumen.it/test.xml', $result);
+        $this->assertEquals('http://rss.service.com/test.xml', $result);
     }
 }

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -15,6 +15,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
     {
         $this->feed->title = 'TestTitle';
         $this->feed->description = 'TestDescription';
+        $this->feed->domain = 'http://roumen.it/';
         $this->feed->link = 'http://roumen.it/';
         $this->feed->ref = 'hub';
         $this->feed->logo = "http://roumen.it/favicon.png";
@@ -29,6 +30,7 @@ class FeedTest extends Orchestra\Testbench\TestCase
 
         $this->assertEquals('TestTitle', $this->feed->title);
         $this->assertEquals('TestDescription', $this->feed->description);
+        $this->assertEquals('http://roumen.it/', $this->feed->domain);
         $this->assertEquals('http://roumen.it/', $this->feed->link);
         $this->assertEquals('hub', $this->feed->ref);
         $this->assertEquals("http://roumen.it/favicon.png", $this->feed->logo);
@@ -151,4 +153,29 @@ class FeedTest extends Orchestra\Testbench\TestCase
         $this->assertEquals('feed::atom', $this->feed->getView('atom'));
     }
 
+    public function testGetRssLinkByDefault()
+    {
+        $requestUrl = 'http://real.domain.need.to.be.hidden/test.xml';
+        $this->get($requestUrl);
+
+        $reflectionMethod = new ReflectionMethod(Roumen\Feed\Feed::class, 'getRssLink');
+        $reflectionMethod->setAccessible(true);
+        $result = $reflectionMethod->invokeArgs($this->feed, []);
+
+        $this->assertEquals($requestUrl, $result);
+    }
+
+    public function testGetRssLinkWithDomainSetting()
+    {
+        $requestUrl = 'http://real.domain.need.to.be.hidden/test.xml';
+        $this->get($requestUrl);
+
+        $this->feed->domain = 'http://rss.service.com/';
+
+        $reflectionMethod = new ReflectionMethod(Roumen\Feed\Feed::class, 'getRssLink');
+        $reflectionMethod->setAccessible(true);
+        $result = $reflectionMethod->invokeArgs($this->feed, []);
+
+        $this->assertEquals('http://rss.roumen.it/test.xml', $result);
+    }
 }


### PR DESCRIPTION
Hi Roumen,

We need to customize the url of our rss service for a security risk when the real domain will be exposed automatically by `Request::url()`.
