### PR TITLE
Don't use html in author field

### DIFF
--- a/src/views/rss.blade.php
+++ b/src/views/rss.blade.php
@@ -45,7 +45,7 @@
             @if (!empty($item['content']))
             <content:encoded><![CDATA[{!! $item['content'] !!}]]></content:encoded>
             @endif
-            <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">{{ $item['author'] }}</dc:creator>
+            <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">{!! $item['author'] !!}</dc:creator>
             <pubDate>{{ $item['pubdate'] }}</pubDate>
             @if (!empty($item['enclosure']))
             <enclosure


### PR DESCRIPTION
A french accentuated character like "é" will be converted to html and the feed will fail at the W3C validator. (This issue is very similar to a previous one : https://github.com/RoumenDamianoff/laravel-feed/pull/29)